### PR TITLE
v0.11.1

### DIFF
--- a/history.md
+++ b/history.md
@@ -3,6 +3,7 @@
 
 #### v0.11.1
 - Small fix in class `meico.mei.Mei2MusicXmlConverter` to address issue #30.
+- Added method `meico.midi.Midi.append()` to concatenate MIDI sequences.
 
 
 #### v0.11.0

--- a/history.md
+++ b/history.md
@@ -1,6 +1,10 @@
 ### Version History
 
 
+#### v0.11.1
+- Small fix in class `meico.mei.Mei2MusicXmlConverter` to address issue #30.
+
+
 #### v0.11.0
 - Added file `/resources/minimal.mei` which is used by constructor `meico.mei.Mei.Mei()` to instantiate an empty Mei object. The object now contains an MEI with no meaningful content, but when writing it to a file it is valid now. Using this constructor will now require exception handling!
 

--- a/history.md
+++ b/history.md
@@ -1,6 +1,10 @@
 ### Version History
 
 
+#### v0.11.0
+- Added file `/resources/minimal.mei` which is used by constructor `meico.mei.Mei.Mei()` to instantiate an empty Mei object. The object now contains an MEI with no meaningful content, but when writing it to a file it is valid now. Using this constructor will now require exception handling!
+
+
 #### v0.10.0
 - Conversion of MEI to MusicXML implemented. Thanks to [Matthias Nowakowski](https://github.com/mnowakow).
   - `meiHead` nearly completely.

--- a/src/meico/Meico.java
+++ b/src/meico/Meico.java
@@ -5,7 +5,7 @@ package meico;
  * @author Axel Berndt
  */
 public class Meico {
-    public static final String version = "0.11.0";
+    public static final String version = "0.11.1";
 
     public static void main(String[] args) {
         System.out.println("meico v" + Meico.version);

--- a/src/meico/Meico.java
+++ b/src/meico/Meico.java
@@ -5,7 +5,7 @@ package meico;
  * @author Axel Berndt
  */
 public class Meico {
-    public static final String version = "0.10.0";
+    public static final String version = "0.11.0";
 
     public static void main(String[] args) {
         System.out.println("meico v" + Meico.version);

--- a/src/meico/mei/Mei.java
+++ b/src/meico/mei/Mei.java
@@ -24,8 +24,8 @@ public class Mei extends meico.xml.XmlBase {
     /**
      * a default constructor that creates an empty Mei instance
      */
-    public Mei() {
-        super();
+    public Mei() throws ParsingException, IOException {
+        super(Mei.class.getResourceAsStream("/resources/minimal.mei"));
     }
 
     /**

--- a/src/meico/mei/Mei2MusicXmlConverter.java
+++ b/src/meico/mei/Mei2MusicXmlConverter.java
@@ -1,6 +1,5 @@
 package meico.mei;
 
-import com.sun.xml.internal.ws.util.StringUtils;
 import meico.musicxml.MusicXml;
 import nu.xom.*;
 import org.audiveris.proxymusic.*;
@@ -1386,7 +1385,7 @@ public class Mei2MusicXmlConverter {
         if(val == null || val.isEmpty()) {return;}
         val = this.sanitize(val.trim());
         StringBuilder addressBuilder = new StringBuilder();
-        addressBuilder.insert(0, StringUtils.capitalize(e.getLocalName()) +  ":"); // Distributor and Address have very similar children
+        addressBuilder.insert(0, Character.toUpperCase(e.getLocalName().charAt(0)) + e.getLocalName().substring(1) +  ":"); // Distributor and Address have very similar children
         addressBuilder.append(this.endLine);
         addressBuilder.append(val).append(this.endLine);
         this.sourceBuilder.append(addressBuilder);

--- a/src/resources/minimal.mei
+++ b/src/resources/minimal.mei
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title/>
+            </titleStmt>
+            <pubStmt/>
+        </fileDesc>
+    </meiHead>
+    <music/>
+</mei>


### PR DESCRIPTION
v0.11.1
- Small fix in class `meico.mei.Mei2MusicXmlConverter` to address issue #30.
- Added method `meico.midi.Midi.append()` to concatenate MIDI sequences.